### PR TITLE
Fix inline LaTeX equations

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,14 @@
         }
         /* === END OF FIX === */
     </style>
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 </head>
 <body class="antialiased">
 


### PR DESCRIPTION
## Summary
- configure MathJax to support `$..$` inline math

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e99eb38fc8328b9935ae4b41173e6