### PR TITLE
Add WILL AI Assistant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,4 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+\n# Node build artifacts\nwill-assistant/node_modules/

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,8 @@ navigation:
     url: /results/
   - title: "Calculator"
     url: /calculator/
+  - title: "Assistant"
+    url: /assistant/
   - title: "Discussions"
     url: /discussions/
   - title: "About"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,14 @@
         }
         /* === END OF FIX === */
     </style>
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 </head>
 <body class="antialiased">
 

--- a/will-assistant/.gitignore
+++ b/will-assistant/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/will-assistant/README.md
+++ b/will-assistant/README.md
@@ -1,0 +1,20 @@
+# WILL AI Assistant
+
+This React single-page application provides the chat interface for WILL Geometry's AI assistant. It fetches knowledge text files from the main repository and sends user questions to the Gemini API via a proxy server.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Deployment
+
+Build the static files and push them to the `gh-pages` branch so they appear at `https://antonrize.github.io/WILL/assistant/`:
+
+```bash
+npm run deploy
+```
+
+This uses the `gh-pages` package to publish the `dist` folder.

--- a/will-assistant/index.html
+++ b/will-assistant/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WILL AI Assistant</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/will-assistant/package.json
+++ b/will-assistant/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "will-assistant",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "gh-pages": "^5.0.0"
+  },
+  "homepage": "/WILL/assistant"
+}

--- a/will-assistant/src/App.jsx
+++ b/will-assistant/src/App.jsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+const KB_FILES = [
+  'WILL%20DATABASE/WILL%20PART%20I%20SR%20GR.txt',
+  'WILL%20DATABASE/WILL%20PART%20II%20COSMO%20.txt',
+  'WILL%20DATABASE/WILL%20PART%20III%20QM%20.txt'
+];
+
+async function loadKnowledge() {
+  const base = 'https://raw.githubusercontent.com/AntonRize/WILL/main/';
+  const texts = await Promise.all(
+    KB_FILES.map(path => fetch(base + path).then(r => r.text()))
+  );
+  return texts.join('\n');
+}
+
+export default function App() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [knowledge, setKnowledge] = useState('');
+
+  useEffect(() => {
+    loadKnowledge().then(setKnowledge);
+  }, []);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', content: input };
+    setMessages([...messages, userMsg]);
+    setInput('');
+
+    const prompt = `${input}\n\nKnowledge:\n${knowledge}`;
+    const res = await fetch('https://proxy-flame-seven.vercel.app/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    });
+    const data = await res.json();
+    const reply = { role: 'assistant', content: data.reply || data.error };
+    setMessages(m => [...m, reply]);
+  };
+
+  return (
+    <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
+      <h1>WILL AI Assistant</h1>
+      <div style={{ minHeight: '300px', border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+        {messages.map((m, i) => (
+          <p key={i}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
+        ))}
+      </div>
+      <div>
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' ? sendMessage() : null}
+          placeholder="Ask something..."
+          style={{ width: '80%' }}
+        />
+        <button onClick={sendMessage} style={{ marginLeft: '0.5rem' }}>Send</button>
+      </div>
+    </div>
+  );
+}

--- a/will-assistant/src/main.jsx
+++ b/will-assistant/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/will-assistant/vite.config.js
+++ b/will-assistant/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/WILL/assistant/'
+});


### PR DESCRIPTION
## Summary
- add navigation link to the new AI assistant
- include React SPA source code for WILL AI assistant
- document usage and deployment steps
- ignore node modules

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e99eb38fc8328b9935ae4b41173e6