### PR TITLE
Add proxy server with CORS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,5 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+\n# Node build artifacts\nwill-assistant/node_modules/
+\nproxy-server/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -311,5 +311,6 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
-\n# Node build artifacts\nwill-assistant/node_modules/
-\nproxy-server/node_modules/
+# Node build artifacts
+will-assistant/node_modules/
+proxy-server/node_modules/

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,8 @@ navigation:
     url: /results/
   - title: "Calculator"
     url: /calculator/
+  - title: "Assistant"
+    url: /assistant/
   - title: "Discussions"
     url: /discussions/
   - title: "About"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,6 +84,14 @@
         }
         /* === END OF FIX === */
     </style>
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 </head>
 <body class="antialiased">
 

--- a/assistant/index.html
+++ b/assistant/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WILL AI Assistant</title>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const KB_FILES = [
+      'WILL%20DATABASE/WILL%20PART%20I%20SR%20GR.txt',
+      'WILL%20DATABASE/WILL%20PART%20II%20COSMO%20.txt',
+      'WILL%20DATABASE/WILL%20PART%20III%20QM%20.txt'
+    ];
+
+    async function loadKnowledge() {
+      const base = 'https://raw.githubusercontent.com/AntonRize/WILL/main/';
+      const texts = await Promise.all(
+        KB_FILES.map(p => fetch(base + p).then(r => r.text()))
+      );
+      return texts.join('\n');
+    }
+
+    function App() {
+      const [messages, setMessages] = React.useState([]);
+      const [input, setInput] = React.useState('');
+      const [knowledge, setKnowledge] = React.useState('');
+
+      React.useEffect(() => {
+        loadKnowledge().then(setKnowledge);
+      }, []);
+
+      const sendMessage = async () => {
+        if (!input.trim()) return;
+        const userMsg = { role: 'user', content: input };
+        setMessages(prev => [...prev, userMsg]);
+        setInput('');
+
+        const prompt = `${input}\n\nKnowledge:\n${knowledge}`;
+        try {
+          const res = await fetch('https://proxy-flame-seven.vercel.app/api/gemini', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt })
+          });
+          const data = await res.json();
+          const reply = { role: 'assistant', content: data.reply || data.error };
+          setMessages(prev => [...prev, reply]);
+        } catch(err) {
+          setMessages(prev => [...prev, { role: 'assistant', content: 'Error: ' + err.message }]);
+        }
+      };
+
+      return (
+        <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
+          <h1>WILL AI Assistant</h1>
+          <div style={{ minHeight: '300px', border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+            {messages.map((m, i) => (
+              <p key={i}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
+            ))}
+          </div>
+          <div>
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' ? sendMessage() : null}
+              placeholder="Ask something..."
+              style={{ width: '80%' }}
+            />
+            <button onClick={sendMessage} style={{ marginLeft: '0.5rem' }}>Send</button>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/proxy-server/README.md
+++ b/proxy-server/README.md
@@ -6,4 +6,6 @@ This folder contains the Vercel serverless function that forwards requests to th
 2. Deploy the `api` directory.
 3. The function will be available at `https://<your-vercel-app>.vercel.app/api/gemini`.
 
+Use Node.js 18 or later so the built-in `fetch` API is available.
+
 The function sends permissive CORS headers so the React app hosted on GitHub Pages can call it from the browser.

--- a/proxy-server/README.md
+++ b/proxy-server/README.md
@@ -1,0 +1,9 @@
+# Proxy Server
+
+This folder contains the Vercel serverless function that forwards requests to the Google Gemini API. Deploy it to Vercel so the assistant can interact with Gemini without exposing the API key.
+
+1. Set the `GEMINI_API_KEY` environment variable in your Vercel project.
+2. Deploy the `api` directory.
+3. The function will be available at `https://<your-vercel-app>.vercel.app/api/gemini`.
+
+The function sends permissive CORS headers so the React app hosted on GitHub Pages can call it from the browser.

--- a/proxy-server/api/gemini.js
+++ b/proxy-server/api/gemini.js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { prompt } = req.body;
+    const { prompt } = req.body || {};
     if (!prompt) {
       res.status(400).json({ error: 'Missing prompt' });
       return;
@@ -22,6 +22,13 @@ export default async function handler(req, res) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
     });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      res.status(resp.status).json({ error: text });
+      return;
+    }
+
     const data = await resp.json();
     const reply = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
     res.status(200).json({ reply });

--- a/proxy-server/api/gemini.js
+++ b/proxy-server/api/gemini.js
@@ -1,0 +1,31 @@
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  try {
+    const { prompt } = req.body;
+    if (!prompt) {
+      res.status(400).json({ error: 'Missing prompt' });
+      return;
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+    });
+    const data = await resp.json();
+    const reply = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    res.status(200).json({ reply });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/proxy-server/package.json
+++ b/proxy-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "will-proxy-server",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/will-assistant/.gitignore
+++ b/will-assistant/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/will-assistant/README.md
+++ b/will-assistant/README.md
@@ -1,0 +1,22 @@
+# WILL AI Assistant
+
+This React single-page application provides the chat interface for WILL Geometry's AI assistant. It fetches knowledge text files from the main repository and sends user questions to the Gemini API via a proxy server.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Deployment
+
+Build the static files and push them to the `gh-pages` branch so they appear at `https://antonrize.github.io/WILL/assistant/`:
+
+```bash
+npm run deploy
+```
+
+This uses the `gh-pages` package to publish the `dist` folder.
+
+The app expects a proxy endpoint that forwards prompts to the Google Gemini API. Deploy the code under `../proxy-server` to Vercel and set the `GEMINI_API_KEY` environment variable. Update `src/App.jsx` if your proxy URL differs from the sample `proxy-flame-seven` endpoint.

--- a/will-assistant/index.html
+++ b/will-assistant/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WILL AI Assistant</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/will-assistant/package.json
+++ b/will-assistant/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "will-assistant",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "gh-pages": "^5.0.0"
+  },
+  "homepage": "/WILL/assistant"
+}

--- a/will-assistant/src/App.jsx
+++ b/will-assistant/src/App.jsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+const KB_FILES = [
+  'WILL%20DATABASE/WILL%20PART%20I%20SR%20GR.txt',
+  'WILL%20DATABASE/WILL%20PART%20II%20COSMO%20.txt',
+  'WILL%20DATABASE/WILL%20PART%20III%20QM%20.txt'
+];
+
+async function loadKnowledge() {
+  const base = 'https://raw.githubusercontent.com/AntonRize/WILL/main/';
+  const texts = await Promise.all(
+    KB_FILES.map(path => fetch(base + path).then(r => r.text()))
+  );
+  return texts.join('\n');
+}
+
+export default function App() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [knowledge, setKnowledge] = useState('');
+
+  useEffect(() => {
+    loadKnowledge().then(setKnowledge);
+  }, []);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', content: input };
+    setMessages([...messages, userMsg]);
+    setInput('');
+
+    const prompt = `${input}\n\nKnowledge:\n${knowledge}`;
+    const res = await fetch('https://proxy-flame-seven.vercel.app/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    });
+    const data = await res.json();
+    const reply = { role: 'assistant', content: data.reply || data.error };
+    setMessages(m => [...m, reply]);
+  };
+
+  return (
+    <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
+      <h1>WILL AI Assistant</h1>
+      <div style={{ minHeight: '300px', border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+        {messages.map((m, i) => (
+          <p key={i}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
+        ))}
+      </div>
+      <div>
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' ? sendMessage() : null}
+          placeholder="Ask something..."
+          style={{ width: '80%' }}
+        />
+        <button onClick={sendMessage} style={{ marginLeft: '0.5rem' }}>Send</button>
+      </div>
+    </div>
+  );
+}

--- a/will-assistant/src/App.jsx
+++ b/will-assistant/src/App.jsx
@@ -30,14 +30,18 @@ export default function App() {
     setInput('');
 
     const prompt = `${input}\n\nKnowledge:\n${knowledge}`;
-    const res = await fetch('https://proxy-flame-seven.vercel.app/api/gemini', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt })
-    });
-    const data = await res.json();
-    const reply = { role: 'assistant', content: data.reply || data.error };
-    setMessages(m => [...m, reply]);
+    try {
+      const res = await fetch('https://proxy-flame-seven.vercel.app/api/gemini', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+      const data = await res.json();
+      const reply = { role: 'assistant', content: data.reply || data.error };
+      setMessages(m => [...m, reply]);
+    } catch(err) {
+      setMessages(m => [...m, { role: 'assistant', content: 'Error: ' + err.message }]);
+    }
   };
 
   return (

--- a/will-assistant/src/main.jsx
+++ b/will-assistant/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/will-assistant/vite.config.js
+++ b/will-assistant/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/WILL/assistant/'
+});


### PR DESCRIPTION
## Summary
- add serverless proxy with permissive CORS headers
- document deploying the proxy in `will-assistant/README.md`
- ignore proxy server node modules

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e99eb38fc8328b9935ae4b41173e6