### PR TITLE
Fix assistant message formatting

### DIFF
--- a/assistant/index.html
+++ b/assistant/index.html
@@ -60,7 +60,7 @@
           <h1>WILL AI Assistant</h1>
           <div style={{ minHeight: '300px', border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
             {messages.map((m, i) => (
-              <p key={i}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
+              <p key={i} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
             ))}
           </div>
           <div>

--- a/will-assistant/package.json
+++ b/will-assistant/package.json
@@ -14,7 +14,9 @@
     "react-dom": "^18.0.0",
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "remark-gfm": "^3.0.1",
+    "remark-breaks": "^3.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",


### PR DESCRIPTION
## Summary
- keep AI responses readable by allowing line breaks in the old standalone assistant page
- add `remark-gfm` and `remark-breaks` to the React assistant package

## Testing
- `npm install remark-gfm remark-breaks --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861ac4104008328bbec84fdcd4226ba