### PR TITLE
Fix assistant message formatting

### DIFF
--- a/assistant/index.html
+++ b/assistant/index.html
@@ -73,7 +73,7 @@
         <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
           <h1 style={{ textAlign:'center', fontSize:'1.5rem', fontWeight:'600', marginBottom:'0.5rem' }}>WILL AI Assistant</h1>
           {model && <p style={{textAlign:'center', fontSize:'0.875rem', color:'#9CA3AF'}}>Model: {model}</p>}
-          <p style={{textAlign:'center', fontSize:'0.75rem', color:'#9CA3AF', marginBottom:'1rem'}}>AI can make mistakes. Double check with main WILL documentation.</p>
+          <p style={{textAlign:'center', fontSize:'0.75rem', color:'#9CA3AF', marginBottom:'1rem'}}>AI can make mistakes. Double-check with the main WILL documentation.</p>
           <div style={{ minHeight: '300px', border: '1px solid #374151', padding: '1rem', marginBottom: '1rem', borderRadius: '8px' }}>
             {messages.map((m, i) => (
               <p key={i} className={`msg ${m.role}`} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>

--- a/assistant/index.html
+++ b/assistant/index.html
@@ -4,6 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>WILL AI Assistant</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    body { font-family:'Inter',sans-serif; background:#111827; color:#E5E7EB; }
+    .msg { background:#1F2937; padding:16px 20px; border-radius:12px; line-height:1.6; margin-bottom:14px; box-shadow:0 1px 4px #0005; }
+    .msg.user { background:#374151; }
+    .input-row { display:flex; gap:8px; margin-top:16px; }
+    .input-row input { flex:1; background:#111827; border:1px solid #374151; border-radius:8px; color:#E5E7EB; padding:10px 12px; }
+    .input-row button { background:#2563EB; color:#fff; border:none; border-radius:8px; padding:10px 16px; cursor:pointer; }
+  </style>
   <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
@@ -29,6 +41,7 @@
       const [messages, setMessages] = React.useState([]);
       const [input, setInput] = React.useState('');
       const [knowledge, setKnowledge] = React.useState('');
+      const [model, setModel] = React.useState('');
 
       React.useEffect(() => {
         loadKnowledge().then(setKnowledge);
@@ -50,6 +63,7 @@
           const data = await res.json();
           const reply = { role: 'assistant', content: data.reply || data.error };
           setMessages(prev => [...prev, reply]);
+          if (data.model) setModel(data.model);
         } catch(err) {
           setMessages(prev => [...prev, { role: 'assistant', content: 'Error: ' + err.message }]);
         }
@@ -57,21 +71,23 @@
 
       return (
         <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
-          <h1>WILL AI Assistant</h1>
-          <div style={{ minHeight: '300px', border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+          <h1 style={{ textAlign:'center', fontSize:'1.5rem', fontWeight:'600', marginBottom:'0.5rem' }}>WILL AI Assistant</h1>
+          {model && <p style={{textAlign:'center', fontSize:'0.875rem', color:'#9CA3AF'}}>Model: {model}</p>}
+          <p style={{textAlign:'center', fontSize:'0.75rem', color:'#9CA3AF', marginBottom:'1rem'}}>AI can make mistakes. Double check with main WILL documentation.</p>
+          <div style={{ minHeight: '300px', border: '1px solid #374151', padding: '1rem', marginBottom: '1rem', borderRadius: '8px' }}>
             {messages.map((m, i) => (
-              <p key={i}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
+              <p key={i} className={`msg ${m.role}`} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}><strong>{m.role === 'user' ? 'You' : 'AI'}:</strong> {m.content}</p>
             ))}
           </div>
-          <div>
+          <div className="input-row">
             <input
               value={input}
               onChange={e => setInput(e.target.value)}
               onKeyDown={e => e.key === 'Enter' ? sendMessage() : null}
               placeholder="Ask something..."
-              style={{ width: '80%' }}
+              style={{ width: '100%' }}
             />
-            <button onClick={sendMessage} style={{ marginLeft: '0.5rem' }}>Send</button>
+            <button onClick={sendMessage}>Send</button>
           </div>
         </div>
       );

--- a/will-assistant/dist/index.html
+++ b/will-assistant/dist/index.html
@@ -5,10 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WILL AI Assistant</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <script type="module" crossorigin src="/WILL/assistant/assets/index-dad5d57c.js"></script>
   </head>
-  <body>
+  <body class="antialiased">
     <div id="root"></div>
-    
+
   </body>
 </html>

--- a/will-assistant/index.html
+++ b/will-assistant/index.html
@@ -5,8 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WILL AI Assistant</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   </head>
-  <body>
+  <body class="antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/will-assistant/package.json
+++ b/will-assistant/package.json
@@ -14,7 +14,9 @@
     "react-dom": "^18.0.0",
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "remark-gfm": "^3.0.1",
+    "remark-breaks": "^3.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/will-assistant/src/App.css
+++ b/will-assistant/src/App.css
@@ -1,11 +1,16 @@
-body          { font-family: system-ui, sans-serif; background:#f6f7fb; }
+body          { font-family: 'Inter', sans-serif; background:#111827; color:#E5E7EB; }
 .chat-box     { max-width:720px; margin:48px auto; }
-.msg          { background:#fff; padding:16px 20px; border-radius:12px;
-                line-height:1.6; margin-bottom:14px; box-shadow:0 1px 4px #0002; }
-.msg.user     { background:#e8f1ff; }
-.input-row    { display:flex; gap:8px; }
-input,button  { font-size:1rem; padding:10px 12px; }
-button        { cursor:pointer; }
+.title        { text-align:center; font-size:1.5rem; font-weight:600; margin-bottom:0.5rem; }
+.model-name   { text-align:center; font-size:0.875rem; color:#9CA3AF; }
+.disclaimer   { text-align:center; font-size:0.75rem; color:#9CA3AF; margin-bottom:1rem; }
+.msg          { background:#1F2937; padding:16px 20px; border-radius:12px;
+                line-height:1.6; margin-bottom:14px; box-shadow:0 1px 4px #0005; }
+.msg.user     { background:#374151; }
+.input-row    { display:flex; gap:8px; margin-top:16px; }
+input         { flex:1; font-size:1rem; padding:10px 12px; background:#111827;
+                color:#E5E7EB; border:1px solid #374151; border-radius:8px; }
+button        { font-size:1rem; padding:10px 16px; background:#2563EB; color:#fff;
+                border:none; border-radius:8px; cursor:pointer; }
 /*
   This is the real fix for the "wall of text" problem.
   It tells the browser to preserve all line breaks and white space

--- a/will-assistant/src/App.jsx
+++ b/will-assistant/src/App.jsx
@@ -5,6 +5,7 @@ import './App.css';
 export default function App() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
+  const [model, setModel] = useState('');
 
   async function send() {
     if (!input.trim()) return;
@@ -26,11 +27,12 @@ export default function App() {
 
       if (r.ok) {
         // This is the fix: We now pass the debug info into the message state
-        setMessages(m => [...m, { 
-          role: 'ai', 
-          text: data.reply, 
-          debug_raw_response: data.debug_raw_response 
+        setMessages(m => [...m, {
+          role: 'ai',
+          text: data.reply,
+          debug_raw_response: data.debug_raw_response
         }]);
+        if (data.model) setModel(data.model);
       } else {
         const errorText = `Error: ${data.error || 'An unknown server error occurred.'}`;
         setMessages(m => [...m, { role: 'ai', text: errorText }]);
@@ -44,6 +46,12 @@ export default function App() {
 
   return (
     <div className="chat-box">
+      <h1 className="title">WILL AI Assistant</h1>
+      {model && (
+        <p className="model-name">Model: {model}</p>
+      )}
+      <p className="disclaimer">AI can make mistakes. Double check with main WILL documentation.</p>
+
       {/* The spread operator {...m} will now correctly pass all props */}
       {messages.map((m, i) => <ChatMessage key={i} {...m} />)}
       <div className="input-row">

--- a/will-assistant/src/App.jsx
+++ b/will-assistant/src/App.jsx
@@ -50,7 +50,7 @@ export default function App() {
       {model && (
         <p className="model-name">Model: {model}</p>
       )}
-      <p className="disclaimer">AI can make mistakes. Double check with main WILL documentation.</p>
+      <p className="disclaimer">AI can make mistakes. Double-check with the main WILL documentation.</p>
 
       {/* The spread operator {...m} will now correctly pass all props */}
       {messages.map((m, i) => <ChatMessage key={i} {...m} />)}


### PR DESCRIPTION
## Summary
- keep AI responses readable by allowing line breaks in the old standalone assistant page
- add `remark-gfm` and `remark-breaks` to the React assistant package
- restyle the assistant UI with a dark theme consistent with WILL site
- display the model name and a disclaimer

## Testing
- `npm install remark-gfm remark-breaks --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861ac4104008328bbec84fdcd4226ba