### PR TITLE
Fix Decap CMS callback page

### DIFF
--- a/admin/callback.html
+++ b/admin/callback.html
@@ -8,7 +8,10 @@
       background tasks like authentication without loading the full UI.
       This should resolve the errors.
     -->
-    <script src="https://unpkg.com/decap-cms-app@^3.0.0/dist/decap-cms-app.js"></script>
+    <!-- Use the full Decap bundle so the OAuth token from the proxy can be
+         processed correctly. Using the smaller decap-cms-app bundle results
+         in the login page reloading after authentication. -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   </head>
   <body>
   </body>


### PR DESCRIPTION
## Summary
- load the full Decap CMS bundle in `admin/callback.html`
- note why the smaller bundle caused login loops

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870b49bcdd0832896f0b66e6ff21262