### PR TITLE
Fix documents link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ navigation:
   - title: "Geometry"
     url: /geometry/
   - title: "Documents"
-    url: /documents/WILL_PART_I_SR_GR.pdf
+    url: /parts/
   - title: "Results"
     url: /results/
   - title: "Galactic Dynamics"


### PR DESCRIPTION
## Summary
- update navigation in `_config.yml` so "Documents" links to `/parts/`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68771ac79430832882340d77951adfd7