### PR TITLE
Remove gradients, use Tailwind styles

### DIFF
--- a/about.md
+++ b/about.md
@@ -29,7 +29,7 @@ Above all, this document serves as a personal record and reflection of a journey
 
 ## Research Philosophy
 
-<div style="background: #e8f4fd; padding: 25px; border-radius: 10px; margin: 30px 0; border-left: 5px solid #3498db;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #3498db;">
     <h4>Core Principles</h4>
     <ul>
         <li><strong>Geometric Simplicity:</strong> All physics should emerge from elementary geometric relationships</li>
@@ -44,7 +44,7 @@ Above all, this document serves as a personal record and reflection of a journey
 
 ## Current Status
 
-<div style="background: #fff3cd; padding: 20px; border-radius: 10px; margin: 30px 0; border-left: 5px solid #856404;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #856404;">
     <p><strong>This work remains an ongoing exploration</strong>, and further developments may reveal deeper connections between geometry, energy, and the fabric of reality.</p>
 </div>
 

--- a/calculator.md
+++ b/calculator.md
@@ -38,7 +38,7 @@ title: "Galactic Dynamics Calculator"
         }
         
         .calculator-container {
-            background: #1f2937;
+            background-color: rgba(31,41,55,0.5);
             border-radius: 15px;
             padding: 30px 40px;
             margin: 20px auto;
@@ -155,7 +155,7 @@ title: "Galactic Dynamics Calculator"
         }
     </style>
 
-    <div class="calculator-container">
+    <div class="calculator-container bg-gray-800/50 p-6 rounded-lg">
         <div id="loader">Loading SPARC Database...</div>
 
         <div id="calculator-body" style="display: none;">

--- a/discussions/collaboration.md
+++ b/discussions/collaboration.md
@@ -11,6 +11,7 @@ Discussion of research collaborations and joint projects related to WILL Geometr
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Discussion of research collaborations and joint projects related to WILL Geometr
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/cosmology.md
+++ b/discussions/cosmology.md
@@ -11,6 +11,7 @@ Discussion of cosmological models and parameters within the WILL Geometry framew
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Discussion of cosmological models and parameters within the WILL Geometry framew
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/general.md
+++ b/discussions/general.md
@@ -11,6 +11,7 @@ General questions and introductory discussions about WILL Geometry. Perfect for 
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ General questions and introductory discussions about WILL Geometry. Perfect for 
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/index.md
+++ b/discussions/index.md
@@ -13,43 +13,43 @@ Scientific discussion forums for WILL Geometry research. Join conversations with
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin: 30px 0;">
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #e74c3c;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #e74c3c;">
     <h3>⚡ Relativity</h3>
     <p>Special and general relativity within WILL Geometry framework</p>
     <a href="/WILL/discussions/relativity/" style="color: #e74c3c; font-weight: bold;">→ Join Discussion</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #8e44ad;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #8e44ad;">
     <h3>🌌 Cosmology</h3>
     <p>Cosmological models, dark energy, and cosmic evolution</p>
     <a href="/WILL/discussions/cosmology/" style="color: #8e44ad; font-weight: bold;">→ Join Discussion</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #27ae60;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #27ae60;">
     <h3>⚛️ Quantum Mechanics</h3>
     <p>Geometric quantization and atomic physics</p>
     <a href="/WILL/discussions/quantum/" style="color: #27ae60; font-weight: bold;">→ Join Discussion</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #f39c12;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #f39c12;">
     <h3>❓ General Questions</h3>
     <p>Basic questions and introductory discussions</p>
     <a href="/WILL/discussions/general/" style="color: #f39c12; font-weight: bold;">→ Ask Questions</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #0c5460;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #0c5460;">
     <h3>🤔 Philosophy</h3>
     <p>Philosophical implications and broader meaning</p>
     <a href="/WILL/discussions/philosophy/" style="color: #0c5460; font-weight: bold;">→ Join Discussion</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #95a5a6;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #95a5a6;">
     <h3>🤝 Collaboration</h3>
     <p>Research partnerships and joint projects</p>
     <a href="/WILL/discussions/collaboration/" style="color: #95a5a6; font-weight: bold;">→ Join Discussion</a>
 </div>
 
-<div style="background: #f8f9fa; padding: 20px; border-radius: 10px; border-left: 5px solid #721c24;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #721c24;">
     <h3>💻 Technical</h3>
     <p>Website, calculator, and development support</p>
     <a href="/WILL/discussions/technical/" style="color: #721c24; font-weight: bold;">→ Technical Support</a>

--- a/discussions/philosophy.md
+++ b/discussions/philosophy.md
@@ -11,6 +11,7 @@ Discussion of philosophical aspects and broader implications of WILL Geometry. T
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Discussion of philosophical aspects and broader implications of WILL Geometry. T
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/quantum.md
+++ b/discussions/quantum.md
@@ -11,6 +11,7 @@ Discussion of quantum mechanics and atomic physics within the WILL Geometry fram
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Discussion of quantum mechanics and atomic physics within the WILL Geometry fram
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/relativity.md
+++ b/discussions/relativity.md
@@ -11,6 +11,7 @@ Discussion of special and general relativity within the WILL Geometry framework.
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Discussion of special and general relativity within the WILL Geometry framework.
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/discussions/technical.md
+++ b/discussions/technical.md
@@ -11,6 +11,7 @@ Technical discussions about the website, calculator, and development. Report bug
 
 ## 💬 Forum Discussion
 
+<div class="bg-gray-800/50 p-6 rounded-lg">
 <script src="https://utteranc.es/client.js"
         repo="AntonRize/WILL"
         issue-term="title"
@@ -19,6 +20,7 @@ Technical discussions about the website, calculator, and development. Report bug
         crossorigin="anonymous"
         async>
 </script>
+</div>
 
 ---
 

--- a/geometry.md
+++ b/geometry.md
@@ -6,7 +6,7 @@ title: "Interactive Geometry"
 <style>
 .geometry-container {
     margin: 30px 0;
-    background: white;
+    background-color: rgba(31,41,55,0.5);
     border-radius: 15px;
     padding: 25px;
     box-shadow: 0 8px 25px rgba(0,0,0,0.15);
@@ -24,7 +24,7 @@ title: "Interactive Geometry"
 }
 
 .geometry-description {
-    background: linear-gradient(135deg, #e8f4fd 0%, #d5f4e6 100%);
+    background-color: rgba(31,41,55,0.5);
     padding: 20px;
     border-radius: 10px;
     margin: 20px 0;
@@ -32,7 +32,7 @@ title: "Interactive Geometry"
 }
 
 .theorem-box {
-    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+    background-color: rgba(31,41,55,0.5);
     border-radius: 10px;
     padding: 20px;
     margin: 25px 0;
@@ -40,7 +40,7 @@ title: "Interactive Geometry"
 }
 
 .critical-points {
-    background: linear-gradient(135deg, #d5f4e6 0%, #a8edea 100%);
+    background-color: rgba(31,41,55,0.5);
     border-radius: 10px;
     padding: 20px;
     margin: 20px 0;
@@ -55,7 +55,7 @@ title: "Interactive Geometry"
 }
 
 .result-card {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-color: rgba(31,41,55,0.5);
     color: white;
     padding: 20px;
     border-radius: 12px;
@@ -69,7 +69,7 @@ title: "Interactive Geometry"
 }
 
 .placeholder-note {
-    background: #f8f9fa;
+    background-color: rgba(31,41,55,0.5);
     border: 2px dashed #dee2e6;
     border-radius: 8px;
     padding: 15px;
@@ -206,14 +206,14 @@ Explore the geometric foundations of WILL theory through interactive visualizati
         <h4>🔍 Mathematical Derivation of Critical Points</h4>
         
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin: 20px 0;">
-            <div style="background: white; padding: 15px; border-radius: 8px; border-left: 4px solid #e74c3c;">
+            <div class="bg-gray-800/50 p-4 rounded-lg border-l-4" style="border-color: #e74c3c;">
                 <h5>Photon Sphere</h5>
                 <p><strong>κ = √(2/3) ≈ 0.816</strong></p>
                 <p><strong>β = 1/√3 ≈ 0.577</strong></p>
                 <p><strong>r = 1.5Rₛ</strong></p>
             </div>
             
-            <div style="background: white; padding: 15px; border-radius: 8px; border-left: 4px solid #8e44ad;">
+            <div class="bg-gray-800/50 p-4 rounded-lg border-l-4" style="border-color: #8e44ad;">
                 <h5>ISCO</h5>
                 <p><strong>κ = √(1/3) ≈ 0.577</strong></p>
                 <p><strong>β = 1/√6 ≈ 0.408</strong></p>
@@ -221,7 +221,7 @@ Explore the geometric foundations of WILL theory through interactive visualizati
             </div>
         </div>
         
-        <div style="background: #f8f9fa; padding: 15px; border-radius: 8px; margin: 20px 0;">
+        <div class="bg-gray-800/50 p-4 rounded-lg mt-5">
             <h5>At the Critical Point:</h5>
             <ul>
                 <li><strong>θₛ = θ_G</strong> (angle equality)</li>
@@ -232,7 +232,7 @@ Explore the geometric foundations of WILL theory through interactive visualizati
         </div>
     </div>
     
-    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 10px; text-align: center; margin: 20px 0;">
+    <div class="bg-gray-800/50 p-6 rounded-lg text-white text-center my-5">
         <h4>🌟 Interpretive Note</h4>
         <p>While the radii 1.5Rₛ (photon sphere) and 3Rₛ (ISCO) are known from General Relativity, their <strong>spontaneous emergence from angle equality θₛ = θ_G</strong> in WILL Geometry is not imposed but arises from internal energy projection symmetries.</p>
         
@@ -247,25 +247,25 @@ Explore the geometric foundations of WILL theory through interactive visualizati
 ## 🔗 Explore Further
 
 <div class="results-grid">
-    <div style="background: linear-gradient(135deg, #3498db 0%, #2980b9 100%); color: white; padding: 20px; border-radius: 12px; text-align: center;">
+    <div class="bg-gray-800/50 p-6 rounded-lg text-white text-center border-l-4" style="border-color: #3498db;">
         <h4>📚 Research Documents</h4>
         <p>Mathematical derivations behind the geometry</p>
         <a href="/WILL/parts/" style="color: white; text-decoration: underline;">→ Read Full Theory</a>
     </div>
     
-    <div style="background: linear-gradient(135deg, #27ae60 0%, #229954 100%); color: white; padding: 20px; border-radius: 12px; text-align: center;">
+    <div class="bg-gray-800/50 p-6 rounded-lg text-white text-center border-l-4" style="border-color: #27ae60;">
         <h4>🧮 Galaxy Calculator</h4>
         <p>Apply WILL geometry to real data</p>
         <a href="/WILL/calculator/" style="color: white; text-decoration: underline;">→ Test Predictions</a>
     </div>
     
-    <div style="background: linear-gradient(135deg, #8e44ad 0%, #7d3c98 100%); color: white; padding: 20px; border-radius: 12px; text-align: center;">
+    <div class="bg-gray-800/50 p-6 rounded-lg text-white text-center border-l-4" style="border-color: #8e44ad;">
         <h4>📊 Results Overview</h4>
         <p>Complete logical flowcharts</p>
         <a href="/WILL/results/" style="color: white; text-decoration: underline;">→ View Results</a>
     </div>
     
-    <div style="background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%); color: white; padding: 20px; border-radius: 12px; text-align: center;">
+    <div class="bg-gray-800/50 p-6 rounded-lg text-white text-center border-l-4" style="border-color: #f39c12;">
         <h4>💬 Join Discussions</h4>
         <p>Scientific community forums</p>
         <a href="/WILL/discussions/" style="color: white; text-decoration: underline;">→ Enter Forums</a>

--- a/parts.md
+++ b/parts.md
@@ -13,7 +13,7 @@ Complete research documentation in three parts, covering the theoretical foundat
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 30px; margin: 40px 0;">
 
-<div style="background: linear-gradient(135deg, #e8f4fd 0%, #d5f4e6 100%); padding: 25px; border-radius: 15px; border-left: 5px solid #3498db;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #3498db;">
     <h3 style="color: #2c3e50; margin-bottom: 15px;">⚡ Part I: Relativistic Foundations</h3>
     <p style="margin-bottom: 20px; line-height: 1.6;">
         From fundamental postulate to Special and General Relativity through pure projection geometry. 
@@ -22,22 +22,12 @@ Complete research documentation in three parts, covering the theoretical foundat
     <p style="font-size: 14px; color: #666; margin-bottom: 20px;">
         <strong>Topics:</strong> Geometric postulate, SR derivation, GR equivalence, unified field equations
     </p>
-    <a href="/WILL/documents/WILL_PART_I_SR_GR.pdf" target="_blank" style="
-        background: #3498db;
-        color: white;
-        padding: 12px 20px;
-        text-decoration: none;
-        border-radius: 8px;
-        font-weight: bold;
-        display: inline-block;
-        transition: background 0.3s;
-    " onmouseover="this.style.background='#2980b9'" 
-       onmouseout="this.style.background='#3498db'">
+    <a href="/WILL/documents/WILL_PART_I_SR_GR.pdf" target="_blank" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">
         📄 Download Part I
     </a>
 </div>
 
-<div style="background: linear-gradient(135deg, #fff3cd 0%, #d1ecf1 100%); padding: 25px; border-radius: 15px; border-left: 5px solid #8e44ad;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #8e44ad;">
     <h3 style="color: #2c3e50; margin-bottom: 15px;">🌌 Part II: Cosmology</h3>
     <p style="margin-bottom: 20px; line-height: 1.6;">
         Two-parameter cosmology without Friedmann equations. Geometric derivation of dark energy 
@@ -46,22 +36,12 @@ Complete research documentation in three parts, covering the theoretical foundat
     <p style="font-size: 14px; color: #666; margin-bottom: 20px;">
         <strong>Topics:</strong> Cosmic evolution, Ωₘ = 1/3, ΩΛ = 2/3, w = -1, holographic entropy
     </p>
-    <a href="/WILL/documents/WILL_PART_II_Cosmology.pdf" target="_blank" style="
-        background: #8e44ad;
-        color: white;
-        padding: 12px 20px;
-        text-decoration: none;
-        border-radius: 8px;
-        font-weight: bold;
-        display: inline-block;
-        transition: background 0.3s;
-    " onmouseover="this.style.background='#7d3c98'" 
-       onmouseout="this.style.background='#8e44ad'">
+    <a href="/WILL/documents/WILL_PART_II_Cosmology.pdf" target="_blank" class="bg-purple-700 hover:bg-purple-800 text-white font-bold py-2 px-4 rounded inline-block">
         📄 Download Part II
     </a>
 </div>
 
-<div style="background: linear-gradient(135deg, #d5f4e6 0%, #f8d7da 100%); padding: 25px; border-radius: 15px; border-left: 5px solid #27ae60;">
+<div class="bg-gray-800/50 p-6 rounded-lg border-l-4" style="border-color: #27ae60;">
     <h3 style="color: #2c3e50; margin-bottom: 15px;">⚛️ Part III: Quantum Mechanics</h3>
     <p style="margin-bottom: 20px; line-height: 1.6;">
         Atomic structure through geometric quantization without wave functions. 
@@ -70,17 +50,7 @@ Complete research documentation in three parts, covering the theoretical foundat
     <p style="font-size: 14px; color: #666; margin-bottom: 20px;">
         <strong>Topics:</strong> Geometric quantization, α = β derivation, hydrogen spectra, atomic physics
     </p>
-    <a href="/WILL/documents/WILL_PART_III_QM.pdf" target="_blank" style="
-        background: #27ae60;
-        color: white;
-        padding: 12px 20px;
-        text-decoration: none;
-        border-radius: 8px;
-        font-weight: bold;
-        display: inline-block;
-        transition: background 0.3s;
-    " onmouseover="this.style.background='#229954'" 
-       onmouseout="this.style.background='#27ae60'">
+    <a href="/WILL/documents/WILL_PART_III_QM.pdf" target="_blank" class="bg-green-700 hover:bg-green-800 text-white font-bold py-2 px-4 rounded inline-block">
         📄 Download Part III
     </a>
 </div>

--- a/results.md
+++ b/results.md
@@ -19,7 +19,7 @@ Logical flow charts showing how all major physics results emerge from the fundam
 }
 
 .flow-box {
-    background: linear-gradient(135deg, #e8f4fd 0%, #d5f4e6 100%);
+    background-color: rgba(31,41,55,0.5);
     border: 2px solid #3498db;
     border-radius: 10px;
     padding: 15px 20px;
@@ -42,13 +42,13 @@ Logical flow charts showing how all major physics results emerge from the fundam
 }
 
 .postulate-box {
-    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+    background-color: rgba(31,41,55,0.5);
     border-color: #f39c12;
     font-weight: bold;
 }
 
 .result-box {
-    background: linear-gradient(135deg, #d5f4e6 0%, #a8edea 100%);
+    background-color: rgba(31,41,55,0.5);
     border-color: #27ae60;
 }
 
@@ -189,7 +189,7 @@ Logical flow charts showing how all major physics results emerge from the fundam
 
 ## 🎯 Unified Achievement
 
-<div style="text-align: center; margin: 50px 0; padding: 30px; background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); border-radius: 15px; border-left: 5px solid #667eea;">
+<div class="text-center my-12 p-6 bg-gray-800/50 rounded-lg border-l-4" style="border-color: #667eea;">
     <h3 style="color: #2c3e50; margin-bottom: 25px;">🏆 Core Relations</h3>
     
     <div style="font-size: 20px; line-height: 2; margin: 25px 0;">
@@ -248,7 +248,7 @@ $$\Omega_\Lambda = \kappa^2$$
 
 $$W_{ill} = \frac{E \cdot T^2}{M \cdot L^2} = \frac{L_d\,E_0\,T_c\,t_{d}^{2}}{T_d\,m_0\,L_c\,r_{d}^{2}} = 1$$
 
-<div style="text-align: center; margin: 40px 0; padding: 25px; background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%); border-radius: 10px; border-left: 5px solid #6c757d;">
+<div class="text-center my-10 p-6 bg-gray-800/50 rounded-lg border-l-4" style="border-color: #6c757d;">
     <h4 style="color: #2c3e50; margin-bottom: 15px;">⚖️ Theoretical Closure</h4>
     <p style="font-size: 16px; line-height: 1.6; margin-bottom: 15px;">
         The unified field equation completes the <em>ab initio</em> derivation begun with the fundamental postulate:


### PR DESCRIPTION
## Summary
- restyle research part cards with Tailwind classes
- tone down highlights in the about page
- switch geometry and results pages to dark translucent blocks
- wrap discussion pages in consistent containers
- minor style update on the calculator page

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68771aeabb70832884ad694e090a00aa