### PR TITLE
Fix documents link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ navigation:
   - title: "Geometry"
     url: /geometry/
   - title: "Documents"
-    url: /documents/WILL_PART_I_SR_GR.pdf
+    url: /parts/
   - title: "Results"
     url: /results/
   - title: "Galactic Dynamics"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,6 +30,14 @@
             transform: rotate(180deg);
         }
     </style>
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
 </head>
 <body class="antialiased">
 


### PR DESCRIPTION
## Summary
- update navigation in `_config.yml` so "Documents" links to `/parts/`
- enable MathJax on the home page for formulas to render correctly

## Testing
- `jekyll build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68771ac79430832882340d77951adfd7