### PR TITLE
Fix home layout to show index content

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -54,6 +54,10 @@
             </div>
         </section>
 
+        <div class="markdown-content py-8">
+            {{ content }}
+        </div>
+
         <!-- Core Concepts Section -->
         <section class="py-16">
             <div class="text-center mb-12">


### PR DESCRIPTION
## Summary
- allow index.md content to appear by adding `{{ content }}` placeholder to home layout

## Testing
- `node tests/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68773c1e97988328a98e0db2cc5f4287