### PR TITLE
Remove outdated ES6 polyfill

### DIFF
--- a/calculator.md
+++ b/calculator.md
@@ -20,7 +20,6 @@ title: "Galactic Dynamics Calculator"
     </div>
 
     <!-- MathJax for LaTeX rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
     <!-- Plotly.js for graphing -->


### PR DESCRIPTION
## Summary
- drop polyfill.io script from `calculator.md`

## Testing
- `npm install`
- `node tests/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6877ac97a1548328b8252d846f168701