### PR TITLE
Add galaxy metadata panel

### DIFF
--- a/tests/calculator.test.js
+++ b/tests/calculator.test.js
@@ -5,7 +5,7 @@ const html = fs.readFileSync('calculator.md', 'utf8');
 const dom = new JSDOM(html, {runScripts: "dangerously"});
 const window = dom.window;
 
-const mockTable1 = "GALAXY1        1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n";
+const mockTable1 = "GALAXY1     3 10 0.5 2 60.0 5.0 1.0 0.1 1.2 2.0 1.5 20.0 2.0 5.0 80 5 1 REF\n";
 const mockTable2 = [
   "GALAXY1 1 0 50 0 10 20 5",
   "GALAXY1 1 1 60 0 10 20 5",
@@ -18,6 +18,11 @@ function wait(ms){ return new Promise(r => setTimeout(r, ms)); }
 
 (async () => {
   await wait(10); // allow scripts to run
+  const infoText = window.document.getElementById('galaxy-info').textContent;
+  if (!infoText.includes('3 (Sb)')) {
+    console.error('Test failed: galaxy info not populated');
+    process.exit(1);
+  }
   const lambdaSlider = window.document.getElementById('lambda-slider');
   lambdaSlider.value = '2.5';
   lambdaSlider.dispatchEvent(new window.Event('input', {bubbles: true}));


### PR DESCRIPTION
## Summary
- show galaxy metadata next to controls in **calculator.md**
- parse `table1.dat` into `galaxyMeta`
- display Hubble type, distance, inclination, luminosity, V_flat and RC quality
- update tests

## Testing
- `npm install`
- `node tests/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687835708dd083289c5836bfd1b9f158