### PR TITLE
Fix redundant canvas styles

### DIFF
--- a/interactive.html
+++ b/interactive.html
@@ -52,6 +52,11 @@ permalink: /WILL/interactive.html
             margin-right: auto;
             aspect-ratio: 1 / 1;
         }
+        .canvas-container canvas {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
         .slider {
             -webkit-appearance: none;
             width: 100%;
@@ -113,8 +118,6 @@ permalink: /WILL/interactive.html
         header {
            background-color: rgba(17, 24, 39, 0.8);
         }
-        .canvas-container { width: 100%; height: 100%; }
-        .canvas-container canvas { width: 100%; height: 100%; display: block; }
     </style>
 
 <header class="backdrop-blur-lg sticky top-0 z-50 border-b border-gray-700">


### PR DESCRIPTION
## Summary
- keep a single `.canvas-container` style definition
- ensure embedded `<canvas>` fills its parent

## Testing
- `node tests/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688078959ff88328b00d9e0aa5c6e333