### PR TITLE
Fix Chart.js loading order

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,7 @@
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="antialiased">
 

--- a/interactive.md
+++ b/interactive.md
@@ -282,7 +282,6 @@ updateGr();
             <canvas id="qCircle" class="w-full aspect-[1/1] my-6"></canvas>
         </div>
         <script>
-import('https://cdn.jsdelivr.net/npm/chart.js').then(()=>{
  const loop=Array.from({length:361},(_,i)=>i*Math.PI/180);
  const circle=loop.map(t=>({x:Math.cos(t),y:Math.sin(t)}));
 
@@ -299,7 +298,6 @@ import('https://cdn.jsdelivr.net/npm/chart.js').then(()=>{
    chart.data.datasets[1].data=[{x:beta,y:kappa}];
    chart.update();
  };
-});
         </script>
     </div>
 </section>
@@ -406,7 +404,6 @@ updateValues(Number(qSlider.value));
     </p>
 </footer>
 
-<script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- globally load Chart.js in default layout
- remove dynamic import from Q-circle chart
- drop extra Chart.js include from interactive page

## Testing
- `node tests/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6885d3ac51148328a1163ce371b91e06