### PR TITLE
Fix Jekyll build: removed or replaced missing narrative includes

### DIFF
--- a/interactive.md
+++ b/interactive.md
@@ -351,19 +351,6 @@ qSlider.addEventListener("input", e => updateValues(Number(e.target.value)));
 updateValues(Number(qSlider.value));
 </script>
 
-<section id="symmetry" class="scroll-mt-20">
-    <div id="symmetry-content">
-        <!-- {% capture content %}{% include narrative/symmetry.md %}{% endcapture %} 
-{{ content | markdownify }} -->
-    </div>
-</section>
-
-<section id="oneline" class="scroll-mt-20">
-    <div id="oneline-content">
-        <!-- {% capture content %}{% include narrative/oneline.md %}{% endcapture %} 
-{{ content | markdownify }} -->
-    </div>
-</section>
 
 
 


### PR DESCRIPTION
## Summary
- remove unused `symmetry` and `oneline` sections from **interactive.md**
- confirm Jekyll build succeeds

## Testing
- `npm install`
- `node tests/calculator.test.js`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6885f081a7cc8328b567178db8185b4f